### PR TITLE
Reverted the depecated methods and made configuring a custom commenting controller possible

### DIFF
--- a/controllers/EntryController.php
+++ b/controllers/EntryController.php
@@ -45,7 +45,10 @@ class Blog_EntryController extends Blog_Controller_Action
         parent::init();
 
         $this->_blog = new Blog();
-
+        $cfg = $this->config;
+        if ($cfg->customCommenting && class_exists($cfg->customCommenting)) {
+            $this->_commenting = new $cfg->customCommenting();
+        } else
         if (class_exists('Commenting')) {
             $this->_commenting = new Commenting();
         }
@@ -217,4 +220,12 @@ class Blog_EntryController extends Blog_Controller_Action
         exit;
     }
 
+    /**
+     * Sets a custom commenting controller
+     *
+     * @param Commenting $commenting
+     */
+    public function setCustomCommenting(Commenting $commenting) {
+        $this->_commenting = $commenting;
+    }
 }

--- a/controllers/EntryController.php
+++ b/controllers/EntryController.php
@@ -66,7 +66,7 @@ class Blog_EntryController extends Blog_Controller_Action
             throw new Zend_Controller_Action_Exception("No entry with ID '$id'", 404);
         }
 
-        return $this->_forward('show', null, null, array(
+        return $this->forward('show', null, null, array(
             'key' => $entry->getUrlPath()
         ));
     }
@@ -94,7 +94,7 @@ class Blog_EntryController extends Blog_Controller_Action
                 $this->_messenger->addMessage(
                     $this->_translate->_('blog_comment_added')
                 );
-                return $this->_redirect($url);
+                return $this->redirect($url);
             }
         }
         $this->view->entry = $entry;

--- a/controllers/EntryController.php
+++ b/controllers/EntryController.php
@@ -69,7 +69,7 @@ class Blog_EntryController extends Blog_Controller_Action
             throw new Zend_Controller_Action_Exception("No entry with ID '$id'", 404);
         }
 
-        return $this->forward('show', null, null, array(
+        return $this->_forward('show', null, null, array(
             'key' => $entry->getUrlPath()
         ));
     }
@@ -97,7 +97,7 @@ class Blog_EntryController extends Blog_Controller_Action
                 $this->_messenger->addMessage(
                     $this->_translate->_('blog_comment_added')
                 );
-                return $this->redirect($url);
+                return $this->_redirect($url);
             }
         }
         $this->view->entry = $entry;

--- a/models/Blog/Controller/Action.php
+++ b/models/Blog/Controller/Action.php
@@ -28,7 +28,7 @@
  * @author      Rafał Gałka <rafal@modernweb.pl>
  * @copyright   Copyright (c) 2007-2012 ModernWeb (http://www.modernweb.pl)
  */
-abstract class Blog_Controller_Action extends Pimcore_Controller_Action_Frontend
+abstract class Blog_Controller_Action extends Website_Controller_Action
 {
     /**
      * @var Zend_Controller_Request_Http


### PR DESCRIPTION
I needed to be able to insert custom handling of the commenting plugin into the blog, so i made it configurable in the website config. 

I should have been able to do this via the classmap.xml, but Pimcore won't override the class.
